### PR TITLE
Adding additional pipeline status check on destructor.

### DIFF
--- a/coral/pipeline/pipelined_model_runner.cc
+++ b/coral/pipeline/pipelined_model_runner.cc
@@ -142,6 +142,9 @@ PipelinedModelRunner::PipelinedModelRunner(
 }
 
 PipelinedModelRunner::~PipelinedModelRunner() {
+  // returns dicrectly if the pipeline was shutdown.
+  if (!pipeline_on_) return;
+  
   const auto status = ShutdownPipeline();
   if (!status.ok()) {
     LOG(ERROR) << "Failed to shutdown status: " << status;


### PR DESCRIPTION
Adding an additional check of the pipeline status on destructor, and early returns if pipeline have already been shutdown before. 

Early shutdowns on pipeline will result in an additional error message, caused by destructor of [PipelinedModelRunner](https://github.com/google-coral/libcoral/blob/master/coral/pipeline/pipelined_model_runner.cc#L237) class calling ***ShutdownPipeline()*** even if pipeline was already off.

This issue is found on executing [pycoral's example code](https://github.com/google-coral/pycoral/blob/master/examples/model_pipelining_classify_image.py). And there is an [issue](https://github.com/google-coral/pycoral/issues/43#issuecomment-1064708722) relating to it.